### PR TITLE
docs: add CAmap Nordic & Baltic to Forks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ uv run ruff format src tests
 * BE https://mxmap.be/
 * EU https://livenson.github.io/mxmap/
 * LV: https://securit.lv/mxmap
+* [CAmap Nordic & Baltic](https://koldex.github.io/ca-sovereignty-map/) — TLS CA sovereignty for Nordic and Baltic municipalities ([source](https://github.com/koldex/ca-sovereignty-map))
 * See also the forks of this repository
 
 


### PR DESCRIPTION
## Summary

- Adds [CAmap Nordic & Baltic](https://koldex.github.io/ca-sovereignty-map/) to the Forks section in README.md — a fork mapping TLS CA sovereignty for Nordic and Baltic municipalities

Closes #18

## Test plan

- [x] Verify the links resolve correctly
- [x] Confirm README formatting renders properly